### PR TITLE
회원 서버 - 경매 서버 포인트 환불 로직 구현

### DIFF
--- a/src/main/java/org/indoles/memberserviceserver/core/controller/MemberController.java
+++ b/src/main/java/org/indoles/memberserviceserver/core/controller/MemberController.java
@@ -1,6 +1,7 @@
 package org.indoles.memberserviceserver.core.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.indoles.memberserviceserver.core.controller.interfaces.Buyer;
 import org.indoles.memberserviceserver.core.controller.interfaces.Login;
 import org.indoles.memberserviceserver.core.controller.interfaces.PublicAccess;
 import org.indoles.memberserviceserver.core.controller.interfaces.Roles;
@@ -78,7 +79,7 @@ public class MemberController {
     /**
      * 경매 서버 - 입찰 시 포인트 전송을 위한 API
      */
-    @Roles({Role.BUYER, Role.SELLER})
+    @Buyer
     @PostMapping("/points/transfer")
     public ResponseEntity<TransferPointResponse> transferPoint(
             @Login SignInfoRequest signInfoRequest,
@@ -100,7 +101,8 @@ public class MemberController {
     /**
      * 경매 서버 - 환불 시 포인트 환불을 위한 API
      */
-    @Roles({Role.BUYER, Role.SELLER})
+
+    @Buyer
     @PostMapping("/points/refund")
     public ResponseEntity<RefundResponse> refundPoint(
             @Login SignInfoRequest signInfoRequest,


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 경매 서버와 회원 서버간 포인트 환불 로직을 구현한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X]  경매 서버 - 회원 서버 포인트 환불 연동 로직 구현


---